### PR TITLE
[1기 박정미][3~5주차] 8, 9월 TIL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@
 |2021.08.11|[TIL] 데브코스 W2D3|SELECT, GROUP BY 실습|[링크](https://velog.io/@jummi10/TIL-devcourse-W2D3)|
 |2021.08.12|[TIL] 데브코스 W2D4|INSERT, UPDATE, DELETE, JOIN 실습|[링크](https://velog.io/@jummi10/TIL-devcourse-W2D4)|
 |2021.08.13|[TIL] 데브코스 W2D5|트랜잭션, View, Stored Procedure 실습|[링크](https://velog.io/@jummi10/TIL-devcourse-W2D5)|
+
+### Week 3
+
+|날짜|제목|설명|링크|
+|---|---|---|---|
+|2021.08.16|[TIL] 데브코스 W3D1|Spring vs Spring Framework vs Spring Boot|[링크](https://velog.io/@jummi10/TIL-devcourse-W3D1)|
+|2021.08.17|[TIL] 데브코스 W3D2|DDD|[링크](https://velog.io/@jummi10/TIL-devcourse-W3D2)|
+|2021.08.20|[TIL] 데브코스 W3D5|Logging|[링크](https://velog.io/@jummi10/TIL-W3D5-Logging)|

--- a/README.md
+++ b/README.md
@@ -39,3 +39,12 @@
 |2021.08.24|[TIL] 데브코스 W4D2|SQL Dialect|[링크](https://velog.io/@jummi10/TIL-devcourse-W4D2-SQL-Dialect)|
 |2021.08.26|[TIL] 데브코스 W4D4|NamedParameterJdbcTemplate|[링크](https://velog.io/@jummi10/TIL-W4D4-NamedParameterJdbcTemplate)|
 |2021.08.27|[TIL] 데브코스 W4D5|AOP, Transaction|[링크](https://velog.io/@jummi10/TIL-W4D5-AOP-Transaction)|
+
+### Week 5
+
+|날짜|제목|설명|링크|
+|---|---|---|---|
+|2021.08.30|[TIL] 데브코스 W5D1|절대경로, 상대경로|[링크](https://velog.io/@jummi10/TIL-W5D1-directory)|
+|2021.08.31|[TIL] 데브코스 W5D2|DispatcherServlet|[링크](https://velog.io/@jummi10/TIL-devcourse-W5D2-DispatcherServlet)|
+|2021.09.01|[TIL] 데브코스 W5D3|Docker 업데이트 오류 해결|[링크](https://velog.io/@jummi10/Docker-solve-update-error)|
+|2021.09.03|[TIL] 데브코스 W5D5|SpringBoot AutoConfiguration|[링크](https://velog.io/@jummi10/TIL-devcourse-W5D5-SpringBoot-AutoConfiguration)|

--- a/README.md
+++ b/README.md
@@ -30,3 +30,12 @@
 |2021.08.16|[TIL] 데브코스 W3D1|Spring vs Spring Framework vs Spring Boot|[링크](https://velog.io/@jummi10/TIL-devcourse-W3D1)|
 |2021.08.17|[TIL] 데브코스 W3D2|DDD|[링크](https://velog.io/@jummi10/TIL-devcourse-W3D2)|
 |2021.08.20|[TIL] 데브코스 W3D5|Logging|[링크](https://velog.io/@jummi10/TIL-W3D5-Logging)|
+
+### Week 4
+
+|날짜|제목|설명|링크|
+|---|---|---|---|
+|2021.08.23|[TIL] 데브코스 W4D1|Test|[링크](https://velog.io/@jummi10/TIL-devcourse-W4D1-Test)|
+|2021.08.24|[TIL] 데브코스 W4D2|SQL Dialect|[링크](https://velog.io/@jummi10/TIL-devcourse-W4D2-SQL-Dialect)|
+|2021.08.26|[TIL] 데브코스 W4D4|NamedParameterJdbcTemplate|[링크](https://velog.io/@jummi10/TIL-W4D4-NamedParameterJdbcTemplate)|
+|2021.08.27|[TIL] 데브코스 W4D5|AOP, Transaction|[링크](https://velog.io/@jummi10/TIL-W4D5-AOP-Transaction)|


### PR DESCRIPTION
### Week 3

|날짜|제목|설명|링크|
|---|---|---|---|
|2021.08.16|[TIL] 데브코스 W3D1|Spring vs Spring Framework vs Spring Boot|[링크](https://velog.io/@jummi10/TIL-devcourse-W3D1)|
|2021.08.17|[TIL] 데브코스 W3D2|DDD|[링크](https://velog.io/@jummi10/TIL-devcourse-W3D2)|
|2021.08.20|[TIL] 데브코스 W3D5|Logging|[링크](https://velog.io/@jummi10/TIL-W3D5-Logging)|

### Week 4

|날짜|제목|설명|링크|
|---|---|---|---|
|2021.08.23|[TIL] 데브코스 W4D1|Test|[링크](https://velog.io/@jummi10/TIL-devcourse-W4D1-Test)|
|2021.08.24|[TIL] 데브코스 W4D2|SQL Dialect|[링크](https://velog.io/@jummi10/TIL-devcourse-W4D2-SQL-Dialect)|
|2021.08.26|[TIL] 데브코스 W4D4|NamedParameterJdbcTemplate|[링크](https://velog.io/@jummi10/TIL-W4D4-NamedParameterJdbcTemplate)|
|2021.08.27|[TIL] 데브코스 W4D5|AOP, Transaction|[링크](https://velog.io/@jummi10/TIL-W4D5-AOP-Transaction)|

### Week 5

|날짜|제목|설명|링크|
|---|---|---|---|
|2021.08.30|[TIL] 데브코스 W5D1|절대경로, 상대경로|[링크](https://velog.io/@jummi10/TIL-W5D1-directory)|
|2021.08.31|[TIL] 데브코스 W5D2|DispatcherServlet|[링크](https://velog.io/@jummi10/TIL-devcourse-W5D2-DispatcherServlet)|
|2021.09.01|[TIL] 데브코스 W5D3|Docker 업데이트 오류 해결|[링크](https://velog.io/@jummi10/Docker-solve-update-error)|
|2021.09.03|[TIL] 데브코스 W5D5|SpringBoot AutoConfiguration|[링크](https://velog.io/@jummi10/TIL-devcourse-W5D5-SpringBoot-AutoConfiguration)|


#### 느낀 점
9월에는 TIL을 매일 쓸 수 있도록 신경쓸 예정입니다.