### PR TITLE
[1기 남명훈][6주차] 09월 06일 ~ 09월 12일TIL

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,4 @@ TIL은 <b>Today I Learn</b> 의 약어이며, 오늘 공부 한 내용을 매일
 | ---------- | ------------ | ------------------------------------------------------ | ------------------------------------------------ |
 | 2021.09.06 | TIL - Day 26 | Programmers Web Devcourse FE 1th - Day 26의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-26) |
 | 2021.09.07 | TIL - Day 27 | Programmers Web Devcourse FE 1th - Day 27의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-27) |
+| 2021.09.08 | TIL - Day 28 | Programmers Web Devcourse FE 1th - Day 28의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-28) |

--- a/README.md
+++ b/README.md
@@ -114,3 +114,4 @@ TIL은 <b>Today I Learn</b> 의 약어이며, 오늘 공부 한 내용을 매일
 | 날짜       | 제목         | 설명                                                   | 링크                                             |
 | ---------- | ------------ | ------------------------------------------------------ | ------------------------------------------------ |
 | 2021.09.06 | TIL - Day 26 | Programmers Web Devcourse FE 1th - Day 26의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-26) |
+| 2021.09.07 | TIL - Day 27 | Programmers Web Devcourse FE 1th - Day 27의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-27) |

--- a/README.md
+++ b/README.md
@@ -116,3 +116,4 @@ TIL은 <b>Today I Learn</b> 의 약어이며, 오늘 공부 한 내용을 매일
 | 2021.09.06 | TIL - Day 26 | Programmers Web Devcourse FE 1th - Day 26의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-26) |
 | 2021.09.07 | TIL - Day 27 | Programmers Web Devcourse FE 1th - Day 27의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-27) |
 | 2021.09.08 | TIL - Day 28 | Programmers Web Devcourse FE 1th - Day 28의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-28) |
+| 2021.09.09 | TIL - Day 29 | Programmers Web Devcourse FE 1th - Day 29의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-29) |

--- a/README.md
+++ b/README.md
@@ -111,10 +111,11 @@ TIL은 <b>Today I Learn</b> 의 약어이며, 오늘 공부 한 내용을 매일
 
 ## ✍ Week 6
 
-| 날짜       | 제목         | 설명                                                   | 링크                                             |
-| ---------- | ------------ | ------------------------------------------------------ | ------------------------------------------------ |
-| 2021.09.06 | TIL - Day 26 | Programmers Web Devcourse FE 1th - Day 26의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-26) |
-| 2021.09.07 | TIL - Day 27 | Programmers Web Devcourse FE 1th - Day 27의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-27) |
-| 2021.09.08 | TIL - Day 28 | Programmers Web Devcourse FE 1th - Day 28의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-28) |
-| 2021.09.09 | TIL - Day 29 | Programmers Web Devcourse FE 1th - Day 29의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-29) |
-| 2021.09.10 | TIL - Day 29 | Programmers Web Devcourse FE 1th - Day 30의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-30) |
+| 날짜          | 제목         | 설명                                                   | 링크                                             |
+| ------------- | ------------ | ------------------------------------------------------ | ------------------------------------------------ |
+| 2021.09.06    | TIL - Day 26 | Programmers Web Devcourse FE 1th - Day 26의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-26) |
+| 2021.09.07    | TIL - Day 27 | Programmers Web Devcourse FE 1th - Day 27의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-27) |
+| 2021.09.08    | TIL - Day 28 | Programmers Web Devcourse FE 1th - Day 28의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-28) |
+| 2021.09.09    | TIL - Day 29 | Programmers Web Devcourse FE 1th - Day 29의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-29) |
+| 2021.09.10    | TIL - Day 29 | Programmers Web Devcourse FE 1th - Day 30의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-30) |
+| 2021.09.11~12 | TIL - Week 6 | Programmers Web Devcourse FE 1th - Week 6의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Week-6) |

--- a/README.md
+++ b/README.md
@@ -108,3 +108,9 @@ TIL은 <b>Today I Learn</b> 의 약어이며, 오늘 공부 한 내용을 매일
 | 2021.09.02    | TIL - Day 24 | Programmers Web Devcourse FE 1th - Day 24의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-24) |
 | 2021.09.03    | TIL - Day 25 | Programmers Web Devcourse FE 1th - Day 25의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-25) |
 | 2021.09.04~05 | TIL - Week 5 | Programmers Web Devcourse FE 1th - Week 5의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Week-5) |
+
+## ✍ Week 6
+
+| 날짜       | 제목         | 설명                                                   | 링크                                             |
+| ---------- | ------------ | ------------------------------------------------------ | ------------------------------------------------ |
+| 2021.09.06 | TIL - Day 26 | Programmers Web Devcourse FE 1th - Day 26의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-26) |

--- a/README.md
+++ b/README.md
@@ -117,3 +117,4 @@ TIL은 <b>Today I Learn</b> 의 약어이며, 오늘 공부 한 내용을 매일
 | 2021.09.07 | TIL - Day 27 | Programmers Web Devcourse FE 1th - Day 27의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-27) |
 | 2021.09.08 | TIL - Day 28 | Programmers Web Devcourse FE 1th - Day 28의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-28) |
 | 2021.09.09 | TIL - Day 29 | Programmers Web Devcourse FE 1th - Day 29의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-29) |
+| 2021.09.10 | TIL - Day 29 | Programmers Web Devcourse FE 1th - Day 30의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-30) |


### PR DESCRIPTION
| 날짜 | 제목  | 설명              | 링크     |
| ---- | ----- | ----------------- | -------- |
| 2021.09.06 | TIL - Day 26 | Programmers Web Devcourse FE 1th - Day 26의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-26) |
| 2021.09.07 | TIL - Day 27 | Programmers Web Devcourse FE 1th - Day 27의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-27) |
| 2021.09.08 | TIL - Day 28 | Programmers Web Devcourse FE 1th - Day 28의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-28) |
| 2021.09.09 | TIL - Day 29 | Programmers Web Devcourse FE 1th - Day 29의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-29) |
| 2021.09.10    | TIL - Day 30 | Programmers Web Devcourse FE 1th - Day 30의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-30) |
| 2021.09.11~12 | TIL - Week 6 | Programmers Web Devcourse FE 1th - Week 6의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Week-6) |