### PR TITLE
[1기 남명훈][7주차] 09월 13일 ~ 09월 19일 TIL

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,4 @@ TIL은 <b>Today I Learn</b> 의 약어이며, 오늘 공부 한 내용을 매일
 | 2021.09.14 | TIL - Day 32 | Programmers Web Devcourse FE 1th - Day 32의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-32) |
 | 2021.09.15 | TIL - Day 33 | Programmers Web Devcourse FE 1th - Day 33의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-33) |
 | 2021.09.16 | TIL - Day 34 | Programmers Web Devcourse FE 1th - Day 34의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-34) |
+| 2021.09.17 | TIL - Day 35 | Programmers Web Devcourse FE 1th - Day 35의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-35) |

--- a/README.md
+++ b/README.md
@@ -122,10 +122,11 @@ TIL은 <b>Today I Learn</b> 의 약어이며, 오늘 공부 한 내용을 매일
 
 ## ✍ Week 7
 
-| 날짜       | 제목         | 설명                                                   | 링크                                             |
-| ---------- | ------------ | ------------------------------------------------------ | ------------------------------------------------ |
-| 2021.09.13 | TIL - Day 31 | Programmers Web Devcourse FE 1th - Day 31의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-31) |
-| 2021.09.14 | TIL - Day 32 | Programmers Web Devcourse FE 1th - Day 32의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-32) |
-| 2021.09.15 | TIL - Day 33 | Programmers Web Devcourse FE 1th - Day 33의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-33) |
-| 2021.09.16 | TIL - Day 34 | Programmers Web Devcourse FE 1th - Day 34의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-34) |
-| 2021.09.17 | TIL - Day 35 | Programmers Web Devcourse FE 1th - Day 35의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-35) |
+| 날짜          | 제목         | 설명                                                   | 링크                                             |
+| ------------- | ------------ | ------------------------------------------------------ | ------------------------------------------------ |
+| 2021.09.13    | TIL - Day 31 | Programmers Web Devcourse FE 1th - Day 31의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-31) |
+| 2021.09.14    | TIL - Day 32 | Programmers Web Devcourse FE 1th - Day 32의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-32) |
+| 2021.09.15    | TIL - Day 33 | Programmers Web Devcourse FE 1th - Day 33의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-33) |
+| 2021.09.16    | TIL - Day 34 | Programmers Web Devcourse FE 1th - Day 34의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-34) |
+| 2021.09.17    | TIL - Day 35 | Programmers Web Devcourse FE 1th - Day 35의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-35) |
+| 2021.09.18~19 | TIL - Week 7 | Programmers Web Devcourse FE 1th - Week 7의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Week-7) |

--- a/README.md
+++ b/README.md
@@ -127,3 +127,4 @@ TIL은 <b>Today I Learn</b> 의 약어이며, 오늘 공부 한 내용을 매일
 | 2021.09.13 | TIL - Day 31 | Programmers Web Devcourse FE 1th - Day 31의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-31) |
 | 2021.09.14 | TIL - Day 32 | Programmers Web Devcourse FE 1th - Day 32의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-32) |
 | 2021.09.15 | TIL - Day 33 | Programmers Web Devcourse FE 1th - Day 33의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-33) |
+| 2021.09.16 | TIL - Day 34 | Programmers Web Devcourse FE 1th - Day 34의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-34) |

--- a/README.md
+++ b/README.md
@@ -117,5 +117,11 @@ TIL은 <b>Today I Learn</b> 의 약어이며, 오늘 공부 한 내용을 매일
 | 2021.09.07    | TIL - Day 27 | Programmers Web Devcourse FE 1th - Day 27의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-27) |
 | 2021.09.08    | TIL - Day 28 | Programmers Web Devcourse FE 1th - Day 28의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-28) |
 | 2021.09.09    | TIL - Day 29 | Programmers Web Devcourse FE 1th - Day 29의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-29) |
-| 2021.09.10    | TIL - Day 29 | Programmers Web Devcourse FE 1th - Day 30의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-30) |
+| 2021.09.10    | TIL - Day 30 | Programmers Web Devcourse FE 1th - Day 30의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-30) |
 | 2021.09.11~12 | TIL - Week 6 | Programmers Web Devcourse FE 1th - Week 6의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Week-6) |
+
+## ✍ Week 7
+
+| 날짜       | 제목         | 설명                                                   | 링크                                             |
+| ---------- | ------------ | ------------------------------------------------------ | ------------------------------------------------ |
+| 2021.09.13 | TIL - Day 31 | Programmers Web Devcourse FE 1th - Day 31의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-31) |

--- a/README.md
+++ b/README.md
@@ -125,3 +125,4 @@ TIL은 <b>Today I Learn</b> 의 약어이며, 오늘 공부 한 내용을 매일
 | 날짜       | 제목         | 설명                                                   | 링크                                             |
 | ---------- | ------------ | ------------------------------------------------------ | ------------------------------------------------ |
 | 2021.09.13 | TIL - Day 31 | Programmers Web Devcourse FE 1th - Day 31의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-31) |
+| 2021.09.14 | TIL - Day 32 | Programmers Web Devcourse FE 1th - Day 32의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-32) |

--- a/README.md
+++ b/README.md
@@ -126,3 +126,4 @@ TIL은 <b>Today I Learn</b> 의 약어이며, 오늘 공부 한 내용을 매일
 | ---------- | ------------ | ------------------------------------------------------ | ------------------------------------------------ |
 | 2021.09.13 | TIL - Day 31 | Programmers Web Devcourse FE 1th - Day 31의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-31) |
 | 2021.09.14 | TIL - Day 32 | Programmers Web Devcourse FE 1th - Day 32의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-32) |
+| 2021.09.15 | TIL - Day 33 | Programmers Web Devcourse FE 1th - Day 33의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-33) |


### PR DESCRIPTION
| 날짜 | 제목  | 설명              | 링크     |
| ---- | ----- | ----------------- | -------- |
| 2021.09.13 | TIL - Day 31 | Programmers Web Devcourse FE 1th - Day 31의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-31) |
| 2021.09.14 | TIL - Day 32 | Programmers Web Devcourse FE 1th - Day 32의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-32) |
| 2021.09.15 | TIL - Day 33 | Programmers Web Devcourse FE 1th - Day 33의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-33) |
| 2021.09.16 | TIL - Day 34 | Programmers Web Devcourse FE 1th - Day 34의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-34) |
| 2021.09.17 | TIL - Day 35 | Programmers Web Devcourse FE 1th - Day 35의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Day-35) |
| 2021.09.18~19 | TIL - Week 7 | Programmers Web Devcourse FE 1th - Week 7의 TIL을 기록 | [링크](https://velog.io/@codenmh0822/TIL-Week-7) |